### PR TITLE
REFACTOR --> Intergrated Old download code into next API route

### DIFF
--- a/Sass/base/_reset.scss
+++ b/Sass/base/_reset.scss
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100;0,200;0,400;0,500;0,600;0,700;0,800;1,800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,400;0,500;0,600;0,700;0,800;1,800&display=swap');
 
 //remove padding and add border box
 *,
@@ -28,7 +28,7 @@ body {
   line-height: 1.5;
   //global font for application
   font: {
-    family: 'Raleway', apple-system, BlinkMacSystemFont, San Francisco,
+    family: 'Poppins', apple-system, BlinkMacSystemFont, San Francisco,
       Helvetica Neue, Helvetica, Ubuntu, Roboto, Noto, Segoe UI, Arial,
       sans-serif, 'roboto', sans-serif;
   }

--- a/Sass/components/_all.scss
+++ b/Sass/components/_all.scss
@@ -1,4 +1,4 @@
-@import 'Header';
+@import 'header';
 @import 'footer';
 @import 'footerLeft';
 @import 'footerMid';

--- a/Sass/components/_view.scss
+++ b/Sass/components/_view.scss
@@ -41,6 +41,7 @@
 
     .download-btn {
       font-size: em(16);
+      font-weight: 600;
       background: linear-gradient(to right, #00c9ff, #92fe9d);
       color: white;
       padding: 0.5em 1.5em;
@@ -48,6 +49,16 @@
       text-align: center;
       border-radius: 5px;
       border: none;
+
+      a,
+      a:visited,
+      a:active {
+        color: white;
+      }
+
+      a:hover {
+        text-decoration: none;
+      }
     }
 
     .download {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,6 @@
 import { QueryClientProvider, QueryClient } from "react-query"
 import MainLayout from "../components/mainLayout"
-import "../Css/App.css"
+import "../Sass/App.scss"
 
 const queryClient = new QueryClient();
 

--- a/pages/api/download.js
+++ b/pages/api/download.js
@@ -1,0 +1,41 @@
+"use strict";
+const { requestImageStream } = require("../../services/getImagestream");
+const path = require("path");
+
+//object for holding the MIME types based on the image extension
+const ImageFormats = {
+    ".jpg": "jpeg",
+    ".png": "png",
+    ".gif": "gif"
+};
+
+export default async function download(req, res) {
+    //extract the url and title of the image from query parameters
+    const { title, url } = req.query;
+
+    //get the extension of the image
+    //and wait for query response of the image
+    const extension = path.extname(url);
+    const format = ImageFormats[extension];
+    const response = await requestImageStream(url).catch((e) => {
+        console.log("something wrong", e);
+    });
+
+    //set HTTP headers to let browser know its for downloading
+    //Added a custom header to let the frontend
+    //know the image format when downloading
+    res.setHeader(
+        "Content-Disposition", `attachment; filename=${title}${extension}`,
+    );
+    res.setHeader(
+        "Content-Type", `image/${format}`
+    );
+
+    res.send(response.data);
+};
+
+export const config = {
+    api: {
+        responseLimit: false,
+    },
+}

--- a/pages/view/[id].js
+++ b/pages/view/[id].js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { getOneImage } from "../api/info"
-
+import { getOneImage } from '../api/info';
+import Link from 'next/link';
 import axios from 'axios';
 import numeral from 'numeral';
 import fileDownload from 'js-file-download';
@@ -9,32 +9,9 @@ import fileDownload from 'js-file-download';
 
 function View({ data }) {
 
-  console.log("view", data)
-  // const location = useLocation();
-  // const data = location.state.data;
-  // const [data, setdata] = useState({});
 
-  // const fetchdata = () => {
-  //   axios
-  //     .get('/info/data', { params: { data: data.data } })
-  //     .then(({ data }) => setdata(data));
-  // };
 
-  const downloadRequest = () => {
-    axios
-      .get('/download/image', {
-        params: { url: data.pic, title: data.title },
-        responseType: 'blob',
-      })
-      .then(({ data, headers }) => {
-        fileDownload(data, headers.imgfilename);
-      });
-  };
 
-  // useEffect(() => {
-  //   fetchdata();
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, []);
   return (
     <>
       <div className="view-top">
@@ -48,8 +25,10 @@ function View({ data }) {
         </div>
 
         <div className="view-top-download">
-          <button className="download-btn" onClick={downloadRequest}>
-            Download
+          <button className="download-btn">
+            <Link href={`/api/download?title=${data.title}&url=${data.url}`}>
+              Download
+            </Link>
           </button>
           {/* <span className="view-download-dropdown download-link">
             <p>
@@ -119,19 +98,15 @@ function View({ data }) {
   );
 }
 
-
 export async function getServerSideProps({ query }) {
-  const { id } = query
-  const data = await getOneImage(id)
-
-
+  const { id } = query;
+  const data = await getOneImage(id);
 
   return {
     props: {
-      data
-    }
-  }
-
+      data,
+    },
+  };
 }
 
 export default View;


### PR DESCRIPTION
Image downloading is functional like before


- Transferred the old code to its new home in `/api/download` and changed some things for it to work properly
- Pointed the global stylesheet from the `Css` folder to the `Sass` folder as next has native support for sass files without having to compile continuously like in CRA (might delete the `Css` folder in the future)
- Embedded a link in the download button to trigger the download and fixed the styling of it
- Increased the `responseLimit` in the API config to allow images that are larger than 4MB to be downloaded